### PR TITLE
Wrap event correctly in getReplay.

### DIFF
--- a/lib/inmemory/Sparbuch.js
+++ b/lib/inmemory/Sparbuch.js
@@ -226,7 +226,7 @@ class Sparbuch extends EventEmitter {
                       event.metadata.position <= toPosition);
 
     filteredEvents.forEach(event => {
-      passThrough.write(event);
+      passThrough.write(Event.wrap(event));
     });
     passThrough.end();
 


### PR DESCRIPTION
Hey,

I added a quick fix to wrap the events correctly with `Event.wrap(event)` in `getReplay`.

René